### PR TITLE
feat: add full Docker dev environment

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,37 @@
+FROM node:20-alpine AS base
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+COPY packages/shared/package.json packages/shared/
+COPY packages/server/package.json packages/server/
+COPY packages/client/package.json packages/client/
+
+RUN npm ci
+
+COPY tsconfig.base.json ./
+COPY packages/shared/ packages/shared/
+
+RUN npm run build --workspace=@web-tibia/shared
+
+# --- Dev: mirrors scripts/dev.sh (steps 3-6) ---
+FROM base AS dev
+
+COPY packages/server/ packages/server/
+COPY packages/client/ packages/client/
+
+EXPOSE 3001 5173
+
+CMD ["sh", "-c", "\
+  echo '[SETUP] Running migrations...' && \
+  npm run db:push --workspace=@web-tibia/server -- --force && \
+  echo '[SETUP] Running seed...' && \
+  (npm run db:seed --workspace=@web-tibia/server 2>/dev/null || echo '[SETUP] Seed skipped') && \
+  echo '[SETUP] Starting apps...' && \
+  npx concurrently \
+    --names SERVER,CLIENT \
+    --prefix-colors blue.bold,magenta.bold \
+    --prefix '[{name}]' \
+    --kill-others \
+    'npm run dev --workspace=@web-tibia/server' \
+    'npm run dev --workspace=@web-tibia/client -- --host'"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -12,10 +12,34 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U tibia -d webtibia"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-tibia} -d ${POSTGRES_DB:-webtibia}"]
       interval: 5s
       timeout: 5s
       retries: 5
+
+  app:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+      target: dev
+    container_name: web-tibia-app
+    ports:
+      - "3001:3001"
+      - "5173:5173"
+    environment:
+      DATABASE_URL: postgresql://${POSTGRES_USER:-tibia}:${POSTGRES_PASSWORD:-tibia123}@postgres:5432/${POSTGRES_DB:-webtibia}
+      PORT: 3001
+      NODE_ENV: development
+      VITE_SERVER_URL: http://localhost:3001
+    depends_on:
+      postgres:
+        condition: service_healthy
+    volumes:
+      - ../packages/server/src:/app/packages/server/src
+      - ../packages/client/src:/app/packages/client/src
+      - ../packages/shared/src:/app/packages/shared/src
+    profiles:
+      - full
 
 volumes:
   postgres_data:

--- a/scripts/docker-dev.sh
+++ b/scripts/docker-dev.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+set -e
+
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+compose() {
+  docker compose -f docker/docker-compose.yml --env-file .env --profile full "$@"
+}
+
+echo -e "${GREEN}========================================${NC}"
+echo -e "${GREEN}   Web-Tibia Docker Dev Environment    ${NC}"
+echo -e "${GREEN}========================================${NC}"
+
+if ! docker info > /dev/null 2>&1; then
+  echo -e "${RED}Error: Docker is not running${NC}"
+  exit 1
+fi
+
+case "${1:-up}" in
+  up)
+    echo -e "${YELLOW}Starting all services...${NC}"
+    echo ""
+    echo -e "${GREEN}   Server: http://localhost:3001       ${NC}"
+    echo -e "${GREEN}   Client: http://localhost:5173       ${NC}"
+    echo -e "${GREEN}========================================${NC}"
+    echo ""
+    compose up --build
+    ;;
+  up:d)
+    echo -e "${YELLOW}Starting all services (detached)...${NC}"
+    compose up --build -d
+    echo -e "${GREEN}Services running in background${NC}"
+    echo -e "  Server: http://localhost:3001"
+    echo -e "  Client: http://localhost:5173"
+    echo -e "  Logs:   bash scripts/docker-dev.sh logs"
+    ;;
+  down)
+    echo -e "${YELLOW}Stopping all services...${NC}"
+    compose down
+    ;;
+  clean)
+    echo -e "${YELLOW}Stopping all services and removing volumes...${NC}"
+    compose down -v
+    ;;
+  logs)
+    compose logs -f
+    ;;
+  *)
+    echo "Usage: bash scripts/docker-dev.sh [up|up:d|down|clean|logs]"
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary

- Add multi-stage Dockerfile (base + dev target)
- Add `app` service to docker-compose with `profiles: [full]`
- Add `scripts/docker-dev.sh` for managing Docker dev environment
- Fix healthcheck to use environment variables instead of hardcoded values

## Changes

### `docker/Dockerfile`

Multi-stage build mirroring `scripts/dev.sh` flow:
- **Stage `base`**: `npm ci` + build shared (single install, DRY)
- **Stage `dev`**: migrations + seed + concurrently (server + client)

### `docker/docker-compose.yml`

- New `app` service with `profiles: [full]` (only starts when requested)
- `depends_on` with `condition: service_healthy`
- `environment` overrides `DATABASE_URL` with Docker DNS hostname `postgres`
- Volumes mount `src/` for hot reload
- Healthcheck now uses `${POSTGRES_USER:-tibia}` and `${POSTGRES_DB:-webtibia}`

### `scripts/docker-dev.sh`

Shell script (no Node required) with subcommands: `up`, `up:d`, `down`, `clean`, `logs`

## How to Test

```bash
# Copy env
cp .env.example .env

# Start everything (DB + server + client)
bash scripts/docker-dev.sh

# Open http://localhost:5173
# Enter a name and click "Enter Game"

# Existing workflow still works
docker compose -f docker/docker-compose.yml up -d
```

## Checklist

- [x] `bash scripts/docker-dev.sh` starts DB + server + client without local Node
- [x] `docker compose up` still works with PostgreSQL only (no breaking change)
- [x] Hot reload works for server, client and shared
- [x] Migrations and seed run automatically on first boot
- [x] Healthcheck uses environment variables

Closes #10

---
Generated with [Claude Code](https://claude.ai/claude-code)