### PR TITLE
docs: add .claude/CLAUDE.md and fix setup instructions

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,21 @@
+# CLAUDE.md (project)
+
+## Documentacao do Projeto
+
+Antes de implementar qualquer feature, consultar os docs relevantes:
+
+- [Arquitetura](../docs/plan/01-architecture.md) — Estrutura geral, monorepo, pacotes
+- [Database Schema](../docs/plan/02-database-schema.md) — Tabelas, relacoes, Drizzle ORM
+- [Sprites & Rendering](../docs/plan/03-sprites-rendering.md) — Canvas, sprites, animacoes
+- [Multiplayer](../docs/plan/04-multiplayer.md) — Socket.io, sincronizacao, protocolo
+- [Issues & Roadmap](../docs/plan/05-issues-roadmap.md) — Prioridades, backlog, milestones
+- [Testing](../docs/plan/06-testing.md) — Estrategia de testes, cobertura
+- [Docker Setup](../docs/plan/07-docker-setup.md) — Containers, compose, ambiente local
+- [Monsters & Combat](../docs/plan/08-monsters-combat.md) — Sistema de combate, monstros, loot
+
+
+## Workflow de Desenvolvimento
+
+```
+Issue no GitHub -> Branch -> Código + Testes -> PR -> Review -> Merge
+```

--- a/docs/plan/README.md
+++ b/docs/plan/README.md
@@ -49,8 +49,13 @@ Issue no GitHub -> Branch -> Código + Testes -> PR -> Review -> Merge
 
 ```bash
 # Clone o repositório
-git clone <repo-url>
+git clone git@github.com:omariosouto/web-tibia.git
+
+# Navegue até a pasta do projeto
 cd web-tibia
+
+# Copie o arquivo .env.example para .env e ajuste se necessário
+cp .env.example .env
 
 # Instale dependências
 npm install


### PR DESCRIPTION
## Summary

- Add `.claude/CLAUDE.md` referencing all project planning docs
- Fix setup instructions in `docs/plan/README.md`

## Changes

### `.claude/CLAUDE.md`

Links to all planning docs in `docs/plan/` so AI agents have context before implementing features. Minimal content — just references, no new rules.

### `docs/plan/README.md`

- Replace placeholder `<repo-url>` with actual repo URL
- Add `cp .env.example .env` step to setup instructions

## How to Test

```bash
# Verify CLAUDE.md links resolve
cat .claude/CLAUDE.md

# Verify README setup instructions
cat docs/plan/README.md
```

## Checklist

- [x] `.claude/CLAUDE.md` references all docs in `docs/plan/`
- [x] `docs/plan/README.md` has real repo URL and `.env` instruction

Closes #12

---
Generated with [Claude Code](https://claude.ai/claude-code)